### PR TITLE
ydata-profiling rebuild without abs.yaml

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"


### PR DESCRIPTION
## ydata-profiling 4.1.1 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1368)
[Upstream](https://github.com/FFY00/python-pyproject-metadata)
[Dependencies ](https://github.com/FFY00/python-pyproject-metadata/blob/main/setup.cfg)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added a specific pinning for `scipy` to version `1.9.3` due to upstream requirements for a successful `python 3.11` build